### PR TITLE
core: accept jsonseal.Validator instead of any in Decode

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -31,7 +31,7 @@ func (dec *Decoder) UseNumber() { dec.d.UseNumber() }
 
 func (dec *Decoder) DisallowUnknownFields() { dec.d.DisallowUnknownFields() }
 
-func (dec *Decoder) Decode(v any) error {
+func (dec *Decoder) Decode(v Validator) error {
 	err := dec.d.Decode(v)
 	if err != nil {
 		if dec.unknownFieldSuggestion && strings.HasPrefix(err.Error(), unknownFieldErrPrefix) {
@@ -61,6 +61,11 @@ func (dec *Decoder) Decode(v any) error {
 				}
 			}
 		}
+	}
+
+	err = v.Validate()
+	if err != nil {
+		return err
 	}
 
 	return err

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,6 +1,7 @@
 package jsonseal_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -10,17 +11,13 @@ import (
 func TestDecoder(t *testing.T) {
 	tt := []struct {
 		input    string
-		decoded  any
-		expected any
+		decoded  Data
+		expected Data
 	}{
 		{
-			input: `{ "balance": 50 }`,
-			decoded: struct {
-				Balance int
-			}{},
-			expected: struct {
-				Balance int
-			}{
+			input:   `{ "balance": 50 }`,
+			decoded: Data{},
+			expected: Data{
 				Balance: 50,
 			},
 		},
@@ -34,14 +31,29 @@ func TestDecoder(t *testing.T) {
 	}
 }
 
+type Data struct {
+	ExpiresIn      int    `json:"expires_in"`
+	Balance        int    `json:"balance,omitempty"`
+	unexposedField string //nolint:unused
+	PrivateField   string `json:"-"`
+}
+
+func (d *Data) Validate() error {
+	var grp jsonseal.CheckGroup
+
+	grp.Check(func() error {
+		if d.ExpiresIn < 0 {
+			return errors.New("should have non-zero expiry option")
+		}
+		return nil
+	})
+
+	return grp.Validate()
+}
+
 func TestDecoderWithUnknownFieldSuggestion(t *testing.T) {
 	t.Run("simple json struct tag", func(t *testing.T) {
-		type Data struct {
-			ExpiresIn      int    `json:"expires_in"`
-			Balance        int    `json:"balance,omitempty"`
-			unexposedField string //nolint:unused
-			PrivateField   string `json:"-"`
-		}
+
 		rawData := `{ "expires": 50 }`
 		expectedError := `{"errors":[{"fields":["expires"],"error":"unknown field. Did you mean \"expires_in\""}]}`
 		var d Data
@@ -52,12 +64,9 @@ func TestDecoderWithUnknownFieldSuggestion(t *testing.T) {
 	})
 
 	t.Run("Exported field in struct", func(t *testing.T) {
-		type Data struct {
-			ExpiresIn      int    `json:"expires_in"`
-			Balance        int    `json:"balance,omitempty"`
-			unexposedField string //nolint:unused
-			PrivateField   string `json:"-"`
-			ExportedField  string
+		type Data2 struct {
+			Data
+			ExportedField string
 		}
 		rawData := `{ "exported": 50 }`
 		expectedError := `{"errors":[{"fields":["exported"],"error":"unknown field. Did you mean \"ExportedField\""}]}`

--- a/decode_test.go
+++ b/decode_test.go
@@ -70,7 +70,7 @@ func TestDecoderWithUnknownFieldSuggestion(t *testing.T) {
 		}
 		rawData := `{ "exported": 50 }`
 		expectedError := `{"errors":[{"fields":["exported"],"error":"unknown field. Did you mean \"ExportedField\""}]}`
-		var d Data
+		var d Data2
 		err := jsonseal.NewDecoder(strings.NewReader(rawData)).WithUnknownFieldSuggestion().Decode(&d)
 		if jsonseal.JSONFormat(err) != expectedError {
 			t.Errorf("expected: %s, got %s", expectedError, jsonseal.JSONFormat(err))


### PR DESCRIPTION
Was too much focused on `WithUnknownFieldSuggestion()` and missed this core detail :sweat_smile: 