### PR TITLE
core: make Unmarshal and Decode as pure drop-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ jsonseal provides drop-in replacements for a few things in [encoding/json](https
   err = jsonseal.NewDecoder(data).Decode(&v)
   ```
 
-If you wish to ensure that `jsonseal.Validator` interface is satisfied by validation input, you could use the below alternatives:
+If you wish to ensure that `jsonseal.Validator` interface was implemented by the input at compile time, you could use the below alternatives:
 - `jsonseal.UnmarshalValidate` could be used instead of `jsonseal.Unmarshal`.
 - `jsonseal.DecodeValidate` could be used instead of `jsonseal.Decode`.
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,16 @@ jsonseal provides drop-in replacements for a few things in [encoding/json](https
   err = jsonseal.NewDecoder(data).Decode(&v)
   ```
 
+If you wish to ensure that `jsonseal.Validator` interface is satisfied by validation input, you could use the below alternatives:
+- `jsonseal.UnmarshalValidate` could be used instead of `jsonseal.Unmarshal`.
+- `jsonseal.DecodeValidate` could be used instead of `jsonseal.Decode`.
+
+Alternatively, you could also do the following to ensure the compile time guarantee.
+
+```go
+var _ jsonseal.Validator = &PaymentRequest{}
+```
+
 ### Unknown Field Suggestions
 
 It might be useful to validate if the JSON data contains only the fields that are expected by the struct to which it is decoded to.

--- a/decode.go
+++ b/decode.go
@@ -31,7 +31,7 @@ func (dec *Decoder) UseNumber() { dec.d.UseNumber() }
 
 func (dec *Decoder) DisallowUnknownFields() { dec.d.DisallowUnknownFields() }
 
-func (dec *Decoder) Decode(v Validator) error {
+func (dec *Decoder) Decode(v any) error {
 	err := dec.d.Decode(v)
 	if err != nil {
 		if dec.unknownFieldSuggestion && strings.HasPrefix(err.Error(), unknownFieldErrPrefix) {
@@ -63,12 +63,18 @@ func (dec *Decoder) Decode(v Validator) error {
 		}
 	}
 
-	err = v.Validate()
-	if err != nil {
-		return err
+	if vv, ok := v.(Validator); ok {
+		err = vv.Validate()
+		if err != nil {
+			return err
+		}
 	}
 
 	return err
+}
+
+func (dec *Decoder) DecodeValidate(v Validator) error {
+	return dec.Decode(v)
 }
 
 func (dec *Decoder) Buffered() io.Reader { return dec.d.Buffered() }

--- a/decode_test.go
+++ b/decode_test.go
@@ -61,6 +61,10 @@ func TestDecoderWithUnknownFieldSuggestion(t *testing.T) {
 		if jsonseal.JSONFormat(err) != expectedError {
 			t.Errorf("expected: %s, got %s", expectedError, jsonseal.JSONFormat(err))
 		}
+		err = jsonseal.NewDecoder(strings.NewReader(rawData)).WithUnknownFieldSuggestion().DecodeValidate(&d)
+		if jsonseal.JSONFormat(err) != expectedError {
+			t.Errorf("expected: %s, got %s", expectedError, jsonseal.JSONFormat(err))
+		}
 	})
 
 	t.Run("Exported field in struct", func(t *testing.T) {
@@ -72,6 +76,10 @@ func TestDecoderWithUnknownFieldSuggestion(t *testing.T) {
 		expectedError := `{"errors":[{"fields":["exported"],"error":"unknown field. Did you mean \"ExportedField\""}]}`
 		var d Data2
 		err := jsonseal.NewDecoder(strings.NewReader(rawData)).WithUnknownFieldSuggestion().Decode(&d)
+		if jsonseal.JSONFormat(err) != expectedError {
+			t.Errorf("expected: %s, got %s", expectedError, jsonseal.JSONFormat(err))
+		}
+		err = jsonseal.NewDecoder(strings.NewReader(rawData)).WithUnknownFieldSuggestion().DecodeValidate(&d)
 		if jsonseal.JSONFormat(err) != expectedError {
 			t.Errorf("expected: %s, got %s", expectedError, jsonseal.JSONFormat(err))
 		}

--- a/jsonseal.go
+++ b/jsonseal.go
@@ -15,16 +15,25 @@ type Validator interface {
 }
 
 // Unmarshal is a drop-in replacement for the standard library json.Unmarshal
-func Unmarshal(data []byte, v Validator) error {
+// But performs jsonseal validations if the input implements the [jsonseal.Validator] interface
+func Unmarshal(data []byte, v any) error {
 	err := json.Unmarshal(data, v)
 	if err != nil {
 		return err
 	}
 
-	err = v.Validate()
-	if err != nil {
-		return err
+	if vv, ok := v.(Validator); ok {
+		err = vv.Validate()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+// UnmarshalValidate is like [jsonseal.Unmarshal] but helps to ensure that the input
+// implements the [jsonseal.Validator] interface at compile time
+func UnmarshalValidate(data []byte, v Validator) error {
+	return Unmarshal(data, v)
 }


### PR DESCRIPTION
Use `UnmarshalValidate` or `DecodeValidate` if you would like compile-time guarantee that payload implements `jsonseal.Validator`.